### PR TITLE
- Honour "addressdetails: 0" in options.

### DIFF
--- a/lib/nominatim.js
+++ b/lib/nominatim.js
@@ -47,7 +47,7 @@ Nominatim.reverse = function(options, callback) {
 
 var extend = function(options) {
   for (var i in defaults) {
-    if (!options[i]) {
+    if (options[i] === undefined) {
       options[i] = defaults[i];
     }
   }


### PR DESCRIPTION
When I tried addressdetails: 0 when passing options to nominatim.search, I noticed that it was still specifying addressdetails: 1 (the default) to nominatim.openstreemap.org.

The problem is in the check to see if the passed in options object already has the keys the defaults object has.

You're actually checking against the value of the key in the passed in options, so if a value is 0, the logic overwrites the passed in option with the default.

My fix checks to see if the value is defined instead of checking truthyness.

My fix isn't tested extensively, but it is working for my situation.
