### PR TITLE
Adding 'User-Agent' to http request to avoid being blocked.

### DIFF
--- a/lib/nominatim.js
+++ b/lib/nominatim.js
@@ -17,11 +17,16 @@ function Nominatim() {
 
 };
 
-queue.on('pop', function(item) {  
-  request(item.url + querystring.stringify(item.options), function(err, res) {
-    var results = JSON.parse(res.body);
+queue.on('pop', function(item) {
+  request( {
+        url : item.url + querystring.stringify(item.options),
+        headers : {
+            'User-Agent': 'node-nominatim'
+        }
+    }, function(err, res) {
+        var results = JSON.parse(res.body);
 
-    item.callback(err, item.options, results);	
+        item.callback(err, item.options, results);
   });
 });
 


### PR DESCRIPTION
Based on npm request documentation (https://www.npmjs.com/package/request) and Nominative usage policy (http://wiki.openstreetmap.org/wiki/Nominatim_usage_policy) I added User-Agent HTTP header to avoid being blocked on the requests. 

> You have been temporarily blocked because you have been overusing OSM's geocoding service or because you have not provided sufficient identification of your application. This block will be automatically lifted after a while. Please take the time and adapt your scripts to reduce the number of requests and make sure that you send a valid UserAgent or Referer.

The User-Agent was set to 'node-nominatim'.
